### PR TITLE
Reconfigured page routes

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -9,6 +9,9 @@ import { setContext } from '@apollo/client/link/context';
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 
 import Home from './pages/Home';
+import MyHome from './pages/signedPages/MyHome';
+import Dashboard from './pages/signedPages/Dashboard';
+import FoodLog from './pages/signedPages/FoodLog';
 import UserHome from './pages/UserHome';
 import Navbar from "./components/Navbar";
 import Auth from "./utils/auth";
@@ -43,7 +46,11 @@ function App() {
             <Routes>
               <Route 
                 path="/" 
-                element={Auth.loggedIn() ? <UserHome /> : <Home />} 
+                element={<Home />} 
+              />
+              <Route
+                path="/me/*"
+                element={<MyHome />}
               />
               <Route
                 path="*"

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -23,9 +23,14 @@ const AppNavbar = () => {
           <Navbar.Toggle aria-controls="navbar" />
           <Navbar.Collapse id="navbar" className="d-flex flex-row-reverse">
             <Nav className="ml-auto d-flex">
+              
+
               {/* if user is logged in show logout, else show login */}
               {Auth.loggedIn() ? (
                 <>
+                  <Nav.Link as={Link} to='/me/dashboard'>Dashboard</Nav.Link>
+                  <Nav.Link as={Link} to='/me/foodlog'>Food Log</Nav.Link>
+                  <Nav.Link as={Link} to='/me/settings'>Settings</Nav.Link>
                   <Nav.Link onClick={Auth.logout}>Logout</Nav.Link>
                 </>
               ) : (

--- a/client/src/pages/signedPages/Dashboard.js
+++ b/client/src/pages/signedPages/Dashboard.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const Dashboard = () => {
+    return (
+        <>
+            <p>
+                Dashboard
+            </p>
+        </>
+    )
+}
+
+export default Dashboard;

--- a/client/src/pages/signedPages/FoodLog.js
+++ b/client/src/pages/signedPages/FoodLog.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const FoodLog = () => {
+    return (
+        <>
+            <p>
+                Food Log
+            </p>
+        </>
+    )
+}
+
+export default FoodLog;

--- a/client/src/pages/signedPages/MyHome.js
+++ b/client/src/pages/signedPages/MyHome.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { useQuery } from '@apollo/client';
+
+import { Navigate, useParams } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+
+import Dashboard from './Dashboard';
+import FoodLog from './FoodLog';
+import Settings from './Settings';
+import { GET_ME } from '../../utils/queries';
+import Auth from '../../utils/auth';
+
+function MyHome() {
+    const { userId } = useParams();
+
+    const { loading, error, data } = useQuery(GET_ME);
+    const userData = data?.me;
+
+    // If no user data found, return home (switch to login page)
+    if (error) return <Navigate to="/" />;
+    if (loading) {
+        return 'Loading...';
+    }
+
+    // User found, render dashboard
+
+    return (
+        <>
+            <Routes>
+                {/* 
+                    / can still be used to navigate to Home
+                    /me and /me/dashboard will render the dashboard
+                 */}
+                <Route
+                    path="/"
+                    element={<Dashboard />}
+                />
+                <Route
+                    path="/dashboard"
+                    element={<Dashboard />}
+                />
+                <Route
+                    path="/foodlog"
+                    element={<FoodLog />}
+                />
+                <Route
+                    path="/settings"
+                    element={<Settings />}
+                />
+            </Routes>
+        </>
+    )
+}
+
+export default MyHome;

--- a/client/src/pages/signedPages/Settings.js
+++ b/client/src/pages/signedPages/Settings.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+function Settings () {
+    return (
+        <>
+            <p>
+                Settings
+            </p>
+        </>
+    )
+}
+
+export default Settings;

--- a/client/src/utils/auth.js
+++ b/client/src/utils/auth.js
@@ -12,7 +12,7 @@ class AuthService {
   loggedIn() {
     // Checks if there is a saved token and it's still valid
     const token = this.getToken();
-    return !!token && !this.isTokenExpired(token); // handwaiving here
+    return token && !this.isTokenExpired(token) ? true : false; // handwaiving here
   }
 
   // check if token is expired
@@ -20,6 +20,7 @@ class AuthService {
     try {
       const decoded = decode(token);
       if (decoded.exp < Date.now() / 1000) {
+        localStorage.removeItem('id_token');
         return true;
       } else return false;
     } catch (err) {
@@ -36,7 +37,7 @@ class AuthService {
     // Saves user token to localStorage
     localStorage.setItem('id_token', idToken);
     console.log('trying to go to userhome');
-    window.location.assign('/');
+    window.location.assign('/me');
     console.log('changed window');
   }
 

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -5,6 +5,7 @@ export const GET_ME = gql`
         me {
         _id
         email
+        username
         loggedDays {
             _id
             entries {


### PR DESCRIPTION
**App.js**
- Added '/me/*' path which is used for 'signedPages'

**signedPages**
- Includes MyHome page, which protects routes for Dashboard, FoodLog, and Settings
- If user authentication fails, then redirect to "/" route, otherwise continue to "/me/" (Dashboard)

**Dashboard, FoodLog, Settings**
- Added starter code for these pages.

**Need**
- Need to make context/provider in MyHome to get the current date and pass to child pages. 