### PR TITLE
Added controls-and-totals class for styling controls and data above EntryTables

### DIFF
--- a/client/src/components/EntryTable.js
+++ b/client/src/components/EntryTable.js
@@ -223,11 +223,13 @@ const EntryTable = (props) => {
                 <div className="cals-col"/>
             </div>
 
-            <div className="table-entry">
+            <div className="table-entry totals">
                 <div className="edit-col"></div>
 
                 <div className="name-col">
-                    TOTALS
+                    <p>
+                        TOTALS
+                    </p>
                 </div>
 
                 <div className="macros-col">

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -28,9 +28,9 @@ const AppNavbar = () => {
               {/* if user is logged in show logout, else show login */}
               {Auth.loggedIn() ? (
                 <>
-                  <Nav.Link as={Link} to='/me/dashboard'>Dashboard</Nav.Link>
+                  {/* <Nav.Link as={Link} to='/me/dashboard'>Dashboard</Nav.Link> */}
                   <Nav.Link as={Link} to='/me/foodlog'>Food Log</Nav.Link>
-                  <Nav.Link as={Link} to='/me/settings'>Settings</Nav.Link>
+                  {/* <Nav.Link as={Link} to='/me/settings'>Settings</Nav.Link> */}
                   <Nav.Link onClick={Auth.logout}>Logout</Nav.Link>
                 </>
               ) : (

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -143,8 +143,45 @@ h6 {
   flex-direction: column;
 }
 
+.controls-and-totals {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 16px 16px;
+} 
+
 .day-controls {
   display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.log-totals {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  padding-right: 32px;
+}
+
+.day-controls p, .log-totals p {
+  margin: 0px;
+  
+}
+
+.log-totals-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.log-totals-stat .totals-macro {
+  font-weight: bold;
+  font-size: 16px;
+}
+
+.log-totals-stat .totals-cals {
+  font-weight: bold;
+  font-size: 32px;
 }
 
 /* EntryTable Styles */
@@ -170,7 +207,7 @@ h6 {
   border-bottom: solid 1px rgb(165, 165, 165);
 }
 
-.table-header .name-col p, .table-header .cals-col p {
+.table-header .name-col p, .table-header .cals-col p, .entry-table .totals p {
   font-weight: bolder;
 }
 

--- a/client/src/pages/signedPages/FoodLog.js
+++ b/client/src/pages/signedPages/FoodLog.js
@@ -140,20 +140,34 @@ const FoodLog = () => {
 
     return (
         <div className='content-container food-log'>
-            <div className='day-controls'>
-                <button onClick={viewPrev}>Prev</button>
-                <p>{ day }</p>
-                <button onClick={viewNext}>Next</button>
-            </div>
-            
-            <div className="totals">
-                <p>Carbs: {dailyTotals.carbs}</p>
+            <div className='controls-and-totals'>
+                <div className='day-controls'>
+                    <button onClick={viewPrev}>Prev</button>
+                    <p>{ day }</p>
+                    <button onClick={viewNext}>Next</button>
+                </div>
 
-                <p>Fat: {dailyTotals.fat}</p>
+                <div className="log-totals">
+                    <div className="log-totals-stat">
+                        <p className="totals-macro">{dailyTotals.carbs}g</p>
+                        <p className="totals-label">Carbs</p>
+                    </div>
 
-                <p>Protein: {dailyTotals.protein}</p>
+                    <div className="log-totals-stat">
+                        <p className="totals-macro">{dailyTotals.fat}g</p>
+                        <p className="totals-label">Fat</p>
+                    </div>
 
-                <p>Cals: {dailyTotals.calories}</p>
+                    <div className="log-totals-stat">
+                        <p className="totals-macro">{dailyTotals.protein}g</p>
+                        <p className="totals-label">Protein</p>
+                    </div>
+                    
+                    <div className="log-totals-stat">
+                        <p className="totals-cals">{dailyTotals.calories}</p>
+                        <p className="totals-label">Calories</p>
+                    </div>
+                </div>
             </div>
 
             <EntryTable 

--- a/client/src/pages/signedPages/MyHome.js
+++ b/client/src/pages/signedPages/MyHome.js
@@ -35,7 +35,8 @@ function MyHome() {
                  */}
                 <Route
                     path="/"
-                    element={<Dashboard />}
+                    element={<FoodLog />}
+                    // element={<Dashboard />}
                 />
                 <Route
                     path="/dashboard"


### PR DESCRIPTION
- See image below
![image](https://github.com/ryanafernandez/chewby-calorie-counter/assets/44521081/8af0d378-7c40-4e90-8190-13ff7a8060ab)

- Hid Dashboard and Settings pages from nav bar (under development)
- Need imgs/icons to replace Prev and Next buttons